### PR TITLE
refactor: eliminate all `any` types and tighten ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,13 +16,16 @@ export default [
     },
     rules: {
       ...typescriptEslint.configs.recommended.rules,
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
-      '@typescript-eslint/no-unsafe-function-type': 'off',
-      '@typescript-eslint/no-unused-expressions': 'off',
-      '@typescript-eslint/no-empty-object-type': 'off',
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-unsafe-function-type': 'error',
+      '@typescript-eslint/no-unused-expressions': 'error',
+      '@typescript-eslint/no-empty-object-type': 'error',
     },
   },
 ];

--- a/src/DeepCompositeSymbol.test.ts
+++ b/src/DeepCompositeSymbol.test.ts
@@ -1,5 +1,5 @@
 import { DeepCompositeSymbol } from '../src/tuplerone';
-import { isRef, shallow } from '../src/shallow';
+import { shallow } from '../src/shallow';
 import { describe, it, expect } from 'vitest';
 
 describe(DeepCompositeSymbol.name, () => {
@@ -50,7 +50,7 @@ describe(DeepCompositeSymbol.name, () => {
   it('allows filtering by key', () => {
     const o1 = { a: { c: 1 }, b: 2, _d: 3 };
     const o2 = { ...o1, _d: 4 };
-    const filter = ([key]: [string, any]) => !key.startsWith('_');
+    const filter = ([key]: [string, unknown]) => !key.startsWith('_');
     expect(DeepCompositeSymbol(o1, filter)).toBe(DeepCompositeSymbol(o2, filter));
     expect(DeepCompositeSymbol(o1)).not.toBe(DeepCompositeSymbol(o2));
   });
@@ -58,7 +58,7 @@ describe(DeepCompositeSymbol.name, () => {
   it('allows filtering by key recursively', () => {
     const o1 = { a: { c: 1 }, b: 2, _d: 3 };
     const o2 = { ...o1, a: { ...o1.a, _e: 4 } };
-    const filter = ([key]: [string, any]) => !key.startsWith('_');
+    const filter = ([key]: [string, unknown]) => !key.startsWith('_');
     expect(DeepCompositeSymbol(o1, filter)).toBe(DeepCompositeSymbol(o2, filter));
     expect(DeepCompositeSymbol(o1)).not.toBe(DeepCompositeSymbol(o2));
   });

--- a/src/DeepCompositeSymbol.ts
+++ b/src/DeepCompositeSymbol.ts
@@ -6,7 +6,7 @@ import { isRef, shallowCache } from './shallow';
  * Recursively creates a "composite key" (like a "value identity") for
  * an object's entries (key-value pairs).
  */
-const DeepCompositeSymbol = (object: any, filter?: (entry: [string, any]) => boolean) => {
+const DeepCompositeSymbol = (object: object, filter?: (entry: [string, unknown]) => boolean) => {
   if (shallowCache.has(object) || object[isRef]) {
     return Tuple.unsafeSymbol(object);
   }
@@ -14,16 +14,14 @@ const DeepCompositeSymbol = (object: any, filter?: (entry: [string, any]) => boo
   const entries = filter ? Object.entries(object).filter(filter) : Object.entries(object);
   // Recursively replace non-tuple object values with tuples
   entries.forEach((entry) => update(entry, filter));
-  return Tuple.unsafeSymbol(...flatten(entries));
+  return Tuple.unsafeSymbol(...entries.flat());
 };
 
-const update = (entry: any, filter?: any) => {
+const update = (entry: [string, unknown], filter?: (entry: [string, unknown]) => boolean) => {
   const v = entry[1];
   if (isWeakMapKey(v) && typeof v !== 'symbol' && !(v instanceof Tuple)) {
-    entry[1] = DeepCompositeSymbol(v, filter);
+    entry[1] = DeepCompositeSymbol(v as object, filter);
   }
 };
-
-const flatten = (entries: any[][]) => Array.prototype.concat.apply([], entries);
 
 export default DeepCompositeSymbol;

--- a/src/Tuple.test.ts
+++ b/src/Tuple.test.ts
@@ -5,7 +5,8 @@ describe(Tuple.name, () => {
   const a = {};
   const { tuple } = Tuple;
   it('constructor throws', () => {
-    expect(() => new (Tuple as any)([1, {}], null)).toThrow();
+    // @ts-expect-error -- testing that the constructor throws when localToken is missing
+    expect(() => new Tuple([1, {}], null)).toThrow();
   });
 
   it('static method constructs', () => {

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -1,8 +1,8 @@
 import { Tuple0, TupleN, CompositeSymbol } from './types';
-import { assignArraylike, arraylikeToIterable, getDefaultLazy } from './helpers';
+import { assignArraylike } from './helpers';
 import { tupleKey, symbolKey, getLeaf, getUnsafeLeaf, registry } from './cache';
 
-export default class Tuple<A> extends (Array as any) implements ArrayLike<A>, Iterable<A> {
+export default class Tuple<A> extends Array<A> implements ArrayLike<A>, Iterable<A> {
   [i: number]: A;
   declare length: number;
 
@@ -27,15 +27,15 @@ export default class Tuple<A> extends (Array as any) implements ArrayLike<A>, It
     if (values.length === 0) {
       // Only construct if needed
       if (tuple0 === undefined) {
-        tuple0 = new Tuple([], localToken) as any;
+        tuple0 = new Tuple([], localToken) as unknown as Tuple0;
       }
-      return tuple0 as any;
+      return tuple0 as unknown as TupleN<T>;
     }
-    const leaf = getLeaf(values as any);
-    const ref = leaf.get(tupleKey) as WeakRef<any> | undefined;
+    const leaf = getLeaf(values as readonly unknown[]);
+    const ref = leaf.get(tupleKey) as WeakRef<TupleN<T>> | undefined;
     let tuple = ref && ref.deref();
     if (!tuple) {
-      tuple = new Tuple(values, localToken) as any;
+      tuple = new Tuple(values, localToken) as unknown as TupleN<T>;
       leaf.set(tupleKey, new WeakRef(tuple));
       registry.register(tuple, values as readonly unknown[]);
     }
@@ -43,8 +43,8 @@ export default class Tuple<A> extends (Array as any) implements ArrayLike<A>, It
   }
 
   static symbol<const T extends readonly unknown[]>(...values: T): CompositeSymbol<T> {
-    const leaf = getLeaf(values as any);
-    const ref = leaf.get(symbolKey) as WeakRef<any> | undefined;
+    const leaf = getLeaf(values as readonly unknown[]);
+    const ref = leaf.get(symbolKey) as WeakRef<CompositeSymbol<T>> | undefined;
     let sym = ref && ref.deref();
     if (!sym) {
       sym = Symbol() as CompositeSymbol<T>;
@@ -55,20 +55,20 @@ export default class Tuple<A> extends (Array as any) implements ArrayLike<A>, It
   }
 
   // The exported member is cast as the same type as Tuple.tuple() to avoid duplicating the overloads
-  static unsafe(...values: any[]): any {
-    return getDefaultLazy(
-      tupleKey,
-      () => new UnsafeTuple(values, localToken),
-      getUnsafeLeaf(values),
-    );
+  static unsafe(...values: unknown[]): unknown {
+    const leaf = getUnsafeLeaf(values);
+    if (!leaf.has(tupleKey)) {
+      leaf.set(tupleKey, new UnsafeTuple(values, localToken));
+    }
+    return leaf.get(tupleKey);
   }
 
-  static unsafeSymbol(...values: any[]): any {
-    return getDefaultLazy(symbolKey, Symbol, getUnsafeLeaf(values));
-  }
-
-  [Symbol.iterator](): IterableIterator<A> {
-    return arraylikeToIterable(this);
+  static unsafeSymbol(...values: unknown[]): unknown {
+    const leaf = getUnsafeLeaf(values);
+    if (!leaf.has(symbolKey)) {
+      leaf.set(symbolKey, Symbol());
+    }
+    return leaf.get(symbolKey);
   }
 }
 

--- a/src/ValueObject.test.ts
+++ b/src/ValueObject.test.ts
@@ -32,7 +32,7 @@ describe(ValueObject.name, () => {
   });
 
   it('supports circular objects', () => {
-    const a: any = {};
+    const a: Record<string, unknown> = {};
     const b = { a };
     a.b = b;
     expect(() => ValueObject(a)).toThrow();

--- a/src/ValueObject.ts
+++ b/src/ValueObject.ts
@@ -11,17 +11,17 @@ export type DeepReadonly<A> = {
  */
 export function ValueObject<A extends object>(
   object: A,
-  filter?: (entry: [string, any]) => boolean,
+  filter?: (entry: [string, unknown]) => boolean,
 ): DeepReadonly<A> {
   if (new.target) {
     throw new TypeError('ValueObject is not a constructor');
   }
 
-  if (shallowCache.has(object) || (object as any)[isRef]) {
-    return object as any;
+  if (shallowCache.has(object) || object[isRef]) {
+    return object as unknown as DeepReadonly<A>;
   }
 
-  const key = DeepCompositeSymbol(object, filter);
+  const key = DeepCompositeSymbol(object, filter) as symbol;
   if (cache.has(key)) {
     return cache.get(key) as DeepReadonly<A>;
   }
@@ -35,7 +35,7 @@ export function ValueObject<A extends object>(
   });
 
   const frozen = Object.freeze(Object.fromEntries(mapped)) as DeepReadonly<A>;
-  cache.set(key, frozen);
+  cache.set(key, frozen as object);
   return frozen;
 }
 

--- a/src/WeakishMap.ts
+++ b/src/WeakishMap.ts
@@ -7,7 +7,7 @@ import { isWeakMapKey } from './helpers';
  * storage as needed.
  */
 export default class WeakishMap<A, B> implements GenericMap<A, B> {
-  #weakMap?: WeakMap<any, B>;
+  #weakMap?: WeakMap<object | symbol, B>;
   #map?: Map<A, B>;
   #size = 0;
 

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -30,7 +30,7 @@ describe('prune', () => {
     getLeaf([root, 1, 2, 3]);
     getLeaf([root, 4]);
     prune([root, 1, 2, 3]);
-    const leaf = getLeaf([root]) as any;
+    const leaf = getLeaf([root]);
     expect(leaf.has(1)).toBe(false);
     expect(leaf.has(4)).toBe(true);
   });
@@ -40,7 +40,7 @@ describe('prune', () => {
     getLeaf([root, 1, 2, 3]);
     getLeaf([root, 1, 2]).set(Symbol(), new WeakRef({}));
     prune([root, 1, 2, 3]);
-    const leaf = getLeaf([root, 1]) as any;
+    const leaf = getLeaf([root, 1]);
     expect(leaf.has(2)).toBe(true);
   });
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,37 +5,47 @@ import { getDefaultLazy, isWeakMapKey } from './helpers';
 export const tupleKey = Symbol();
 export const symbolKey = Symbol();
 
-const cache = new WeakishMap();
+// The cache is a recursive DAG: each node stores child nodes keyed by value.
+// We use WeakishMap<unknown, unknown> to represent nodes at every level,
+// casting to the recursive type where getDefaultLazy needs it.
+type CacheNode = WeakishMap<unknown, unknown>;
+const asNodeMap = (m: CacheNode) => m as unknown as WeakishMap<unknown, CacheNode>;
 
-const initWeakish = () => new WeakishMap();
+const cache: CacheNode = new WeakishMap<unknown, unknown>();
 
-export const getLeaf = (values: any[], unsafe?: boolean): WeakishMap<any, any> => {
+const initWeakish = (): CacheNode => new WeakishMap<unknown, unknown>();
+
+export const getLeaf = (values: readonly unknown[], unsafe?: boolean): CacheNode => {
   const rootValue = values.find(isWeakMapKey);
   if (!rootValue && !unsafe) {
     // Throw since it's not possible to weak-reference primitives directly by other primitives
     throw TypeError('At least one value must be suitable as a WeakMap key (object or symbol)');
   }
   // If the first value is not an object/symbol, pad the values with the first object/symbol
-  const root = rootValue === values[0] ? cache : getDefaultLazy(rootValue, initWeakish, cache);
-  return values.reduce((prev, curr) => getDefaultLazy(curr, initWeakish, prev), root);
+  const root =
+    rootValue === values[0] ? cache : getDefaultLazy(rootValue, initWeakish, asNodeMap(cache));
+  return values.reduce<CacheNode>(
+    (prev, curr) => getDefaultLazy(curr, initWeakish, asNodeMap(prev)),
+    root,
+  );
 };
 
-export const prune = (values: readonly any[]) => {
+export const prune = (values: readonly unknown[]) => {
   const rootValue = values.find(isWeakMapKey);
   if (!rootValue) return;
 
-  const stack: [WeakishMap<any, any>, any][] = [];
-  let current: WeakishMap<any, any> | undefined = cache;
+  const stack: [CacheNode, unknown][] = [];
+  let current: CacheNode | undefined = cache;
 
   if (rootValue !== values[0]) {
     stack.push([current, rootValue]);
-    current = current.get(rootValue) as WeakishMap<any, any> | undefined;
+    current = current.get(rootValue) as CacheNode | undefined;
     if (!current) return;
   }
 
   for (const val of values) {
     stack.push([current, val]);
-    current = current.get(val) as WeakishMap<any, any> | undefined;
+    current = current.get(val) as CacheNode | undefined;
     if (!current) return;
   }
 
@@ -54,11 +64,17 @@ export const prune = (values: readonly any[]) => {
 export const registry = new FinalizationRegistry<readonly unknown[]>((path) => void prune(path));
 
 // Unsafe tuples aren't garbage collected so it's more efficient to just use a normal map
-const unsafeCache = new Map();
-const initUnsafe = () => new Map();
+type UnsafeCacheNode = Map<unknown, unknown>;
+const asUnsafeNodeMap = (m: UnsafeCacheNode) => m as unknown as Map<unknown, UnsafeCacheNode>;
+
+const unsafeCache: UnsafeCacheNode = new Map<unknown, unknown>();
+const initUnsafe = (): UnsafeCacheNode => new Map<unknown, unknown>();
 
 /**
  * A memory-leaky, slightly more efficient version of `getLeaf()`.
  */
-export const getUnsafeLeaf = (values: any[]): Map<any, any> =>
-  values.reduce((prev, curr) => getDefaultLazy(curr, initUnsafe, prev), unsafeCache);
+export const getUnsafeLeaf = (values: readonly unknown[]): UnsafeCacheNode =>
+  values.reduce<UnsafeCacheNode>(
+    (prev, curr) => getDefaultLazy(curr, initUnsafe, asUnsafeNodeMap(prev)),
+    unsafeCache,
+  );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -54,22 +54,13 @@ export const assignArraylike = <A>(iterator: Iterator<A>, target: Indexable<A>):
 export const arraylikeToIterable = <A>(source: ArrayLike<A>): IterableIterator<A> => {
   let i = 0;
   return {
-    next() {
-      let done;
-      let value;
+    next(): IteratorResult<A> {
       if (i < source.length) {
-        done = false;
-        value = source[i];
+        const value = source[i];
         i += 1;
-      } else {
-        done = true;
-        // Issue: https://github.com/Microsoft/TypeScript/issues/2983
-        value = <any>undefined;
+        return { done: false, value };
       }
-      return {
-        done,
-        value,
-      };
+      return { done: true, value: undefined };
     },
 
     [Symbol.iterator]() {

--- a/src/memoize.test.ts
+++ b/src/memoize.test.ts
@@ -6,7 +6,7 @@ describe(memoize.name, () => {
   });
 
   it('returns the same object', () => {
-    const f = memoize((a: any) => ({}));
+    const f = memoize((_a: unknown) => ({}));
     const o = f(1);
     expect(f(1)).toBe(o);
     expect(f(1)).toBe(o);
@@ -14,7 +14,7 @@ describe(memoize.name, () => {
   });
 
   it('supports multiple arguments', () => {
-    const f = memoize((a: any, b: any, c: any) => ({}));
+    const f = memoize((_a: unknown, _b: unknown, _c: unknown) => ({}));
     const o = f(1, 2, 3);
     expect(f(1, 2, 3)).toBe(o);
     expect(f(1, 2, 3)).toBe(o);
@@ -22,7 +22,7 @@ describe(memoize.name, () => {
   });
 
   it('supports setting receiver', () => {
-    const f = memoize(function (this: any) {
+    const f = memoize(function (this: unknown) {
       return this;
     });
     expect(f.call(123)).toBe(123);
@@ -30,8 +30,8 @@ describe(memoize.name, () => {
 
   it('receiver is memoized', () => {
     let n = 0;
-    const f = memoize((x: any) => {
-      n += x;
+    const f = memoize((x: unknown) => {
+      n += x as number;
       return n;
     });
     const o = {};
@@ -56,7 +56,7 @@ describe(memoize.name, () => {
 
   it('supports mapping primitive this values properly', () => {
     let calls = 0;
-    const f = memoize(function (this: any) {
+    const f = memoize(function (this: unknown) {
       calls++;
       return this;
     });

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,12 +1,14 @@
 import { getLeaf } from './Tuple';
 import { getDefaultLazy } from './helpers';
 
-const defaultCache = new WeakMap();
+type Fn = (this: unknown, ...args: readonly unknown[]) => unknown;
 
-export const memoize = <A extends Function>(fn: A, cache = defaultCache): A => {
-  const memoized: any = function (this: any, ...args: any[]) {
+const defaultCache = new WeakMap<object, unknown>();
+
+export const memoize = <A extends Fn>(fn: A, cache = defaultCache): A => {
+  const memoized: Fn = function (this: unknown, ...args: readonly unknown[]): unknown {
     const node = getLeaf([memoized, this, ...args]);
-    return getDefaultLazy(node, () => fn.apply(this, args), cache);
+    return getDefaultLazy(node, () => fn.apply(this, args as unknown[]) as unknown, cache);
   };
-  return memoized as A;
+  return memoized as unknown as A;
 };

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -5,10 +5,10 @@ const o = {};
 describe('readme examples', () => {
   it('work', () => {
     expect(Tuple()).toBeInstanceOf(Tuple.constructor);
-    const tuple0: Tuple0 = Tuple(); // 0-tuple
-    const tuple1: Tuple1<typeof o> = Tuple(o); // 1-tuple
-    const tuple2: Tuple2<typeof o, number> = Tuple(o, 1); // 2-tuple
+    const _tuple0: Tuple0 = Tuple(); // 0-tuple
+    const _tuple1: Tuple1<typeof o> = Tuple(o); // 1-tuple
+    const _tuple2: Tuple2<typeof o, number> = Tuple(o, 1); // 2-tuple
     // @ts-ignore
-    Tuple(o) === Tuple(o, 1); // TS compile error due to different arities
+    void (Tuple(o) === Tuple(o, 1)); // TS compile error due to different arities
   });
 });

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -4,13 +4,11 @@
  */
 export const isRef = Symbol('isRef');
 
-interface Referable {
-  [isRef]?: boolean;
-}
-
 declare global {
   // Allow setting the isRef property on any object
-  interface Object extends Referable {}
+  interface Object {
+    [isRef]?: boolean;
+  }
 }
 
 /**

--- a/src/tuplerone.ts
+++ b/src/tuplerone.ts
@@ -1,4 +1,4 @@
-import { unsafe, tuple, unsafeSymbol, symbol } from './Tuple';
+import { unsafe, tuple, unsafeSymbol } from './Tuple';
 import DeepCompositeSymbol from './DeepCompositeSymbol';
 import ValueObject from './ValueObject';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,9 @@ export type Tuple8<A, B, C, D, E, F, G, H> = TupleN<[A, B, C, D, E, F, G, H]>;
 export type CompositeSymbol<T extends readonly unknown[]> = {
   t: T;
 } & symbol;
-export const CompositeSymbol0: CompositeSymbol<readonly []> = Symbol('CompositeSymbol0') as any;
+export const CompositeSymbol0: CompositeSymbol<readonly []> = Symbol(
+  'CompositeSymbol0',
+) as unknown as CompositeSymbol<readonly []>;
 export type CompositeSymbol1<A> = CompositeSymbol<[A]>;
 export type CompositeSymbol2<A, B> = CompositeSymbol<[A, B]>;
 export type CompositeSymbol3<A, B, C> = CompositeSymbol<[A, B, C]>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
## Summary

- Re-enables `no-explicit-any`, `no-unsafe-function-type`, `no-unused-vars`, `no-unused-expressions`, and `no-empty-object-type` ESLint rules as errors/warnings
- Replaces all `any` usages with `unknown`, `as unknown as T` double-casts, or proper generics across the entire codebase
- Updates `tsconfig.json` `lib` from `ES2022` to `ESNext` to unlock `WeakKey = object | symbol` natively (allowing clean `WeakMap<object | symbol, B>` without hacks)

Key per-file changes:
- **`WeakishMap`**: clean `WeakMap<object | symbol, B>` — no casts needed with ESNext lib
- **`cache`**: `CacheNode` type alias + `asNodeMap` cast helper to satisfy `reduce` generic inference
- **`Tuple`**: `extends Array<A>` directly (no `as any` hack); proper `WeakRef<TupleN<T>>` typing
- **`memoize`**: `Fn` type alias replacing banned `Function` type
- **`helpers`**: split `next()` return paths to remove `<any>undefined` workaround
- **`shallow`**: `[isRef]?: boolean` inlined directly into `Object` global augmentation (removes empty interface)
- **Test files**: unused vars prefixed `_`, `@ts-expect-error` replaces `as any` for constructor test, filter callbacks use `[string, unknown]`

## Test plan

- [x] `pnpm run types:check` — zero errors
- [x] `pnpm run lint` — zero errors/warnings
- [x] `pnpm run test` — 77/77 tests passed
- [x] `pnpm run build` — library and docs build succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)